### PR TITLE
Remove confusing "base" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,28 +33,17 @@ In your project's Gruntfile, add a section named `shopify_sass` to the data obje
 ```js
 grunt.initConfig({
     shopify_sass: {
-        options: {
-            // Task-specific options go here.
-        },
         your_target: {
-            // Target-specific file lists and/or options go here.
+            // Target-specific file lists
         },
     },
 });
 ```
 
-### Options
-
-#### options.base
-Type: `String`  
-Default value: `''`
-
-A string value that is used to determine where to find the imported files. If no `base` is provided it defaults to be relative to the `src` file.
-
 ### Usage Examples
 
-#### Default Options
-In this example, we aren't passing any options to the plugin. All of the imports in `styles/theme.scss` will be concatenated into `assets/theme.scss.liquid`.
+#### Simple
+In this example, all of the imports in `styles/theme.scss` will be concatenated into `assets/theme.scss.liquid`.
 
 ```scss
 /* Example "styles.theme.scss" */
@@ -70,7 +59,6 @@ In this example, we aren't passing any options to the plugin. All of the imports
 ```js
 grunt.initConfig({
     shopify_sass: {
-        options: {},
         files: {
             'assets/theme.scss.liquid': "styles/theme.scss"
         },
@@ -78,20 +66,14 @@ grunt.initConfig({
 });
 ```
 
-#### Custom Options
-In this example, the `base` option is used to specify where the imported files should be coming from. We're also providing two different source files.
+#### Multiple sources
+In this example we're using two different source files written in CoffeeScript.
 
-```js
-grunt.initConfig({
-    shopify_sass: {
-        options: {
-            base: "imports"
-        },
-        files: {
-            'assets/theme.scss.liquid': ['styles/theme.scss', 'styles/additional.scss'],
-        },
-    },
-});
+```coffee
+grunt.initConfig
+    shopify_sass:
+        files:
+            'assets/theme.scss.liquid': ['styles/theme.scss', 'styles/additional.scss']
 ```
 
 ## Contributing

--- a/tasks/shopify_sass.js
+++ b/tasks/shopify_sass.js
@@ -14,10 +14,6 @@ module.exports = function(grunt) {
 
     grunt.registerMultiTask('shopify_sass', 'Concatenate your Sass files defined by the @import order.', function() {
 
-        var options = this.options({
-            base: ''
-        });
-
         var rex = /@import\s*(("([^"]+)")|('([^']+)'))\s*;/g;
         var match;
 
@@ -30,16 +26,11 @@ module.exports = function(grunt) {
 
                 var fileContents = grunt.file.read(filepath);
 
-                if( !options.base ) {
-                    // If no base is provided, make it relative to the src file
-                    options.base = path.dirname(filepath);
-                }
-
                 while (match = rex.exec(fileContents)) {
                     // Extract just the source of the file
                     // [3] double quotes, @import "_import-file.scss";
                     // [5] single quotes, @import '_import-file.scss';
-                    sources.push(path.join(options.base, (match[3] || match[5])) );
+                    sources.push(path.join(path.dirname(filepath), (match[3] || match[5])) );
                 }
             });
 


### PR DESCRIPTION
Didn't make much sense as an option. Most developers are going to have
their main Sass file (theme.scss) as the root and all other `@import`
files relative to that anyways.
