### PR TITLE
Add support for target-less tasks

### DIFF
--- a/tasks/shopify_sass.js
+++ b/tasks/shopify_sass.js
@@ -15,12 +15,22 @@ module.exports = function(grunt) {
     grunt.registerMultiTask('shopify_sass', 'Concatenate your Sass files defined by the @import order.', function() {
 
         var rex = /@import\s*(("([^"]+)")|('([^']+)'))\s*;/g;
-        var match;
+        var match, fileIterator;
 
         // Iterate over each src/dest pairing
-        this.files.forEach( function(files) {
+        if (this.files.length !== 0) {
+            fileIterator = this.files;
+        } else if (this.target === "files") {
+            var dataKey = Object.keys(this.data)[0];
+            fileIterator = [{ src: this.data[dataKey], dest: dataKey }];
+        }
+
+        fileIterator.forEach( function(files) {
 
             var fileContents = [];
+
+            if (typeof files.src === "string")
+                files.src = [files.src];
 
             // Iterate over each src file
             files.src.forEach( function(filepath, i) {


### PR DESCRIPTION
Adds support for registering tasks without target names. This fix will allow the following syntax to work:

```
shopify_sass:
    files:
        "assets/theme.scss.liquid": "styles/theme.scss"
    files:
        src: "styles/theme.scss"
        dest: "assets/theme.scss.liquid"
```